### PR TITLE
Add option to specify a custom top margin for the traffic light buttons.

### DIFF
--- a/WAYWindow/WAYWindow.h
+++ b/WAYWindow/WAYWindow.h
@@ -44,6 +44,9 @@
 /// Defines the left margin of the standard window buttons. Defaut: OS X default value.
 @property (nonatomic) IBInspectable CGFloat trafficLightButtonsLeftMargin;
 
+/// Defines the top margin of the standard window buttons. Used if not centered. Defaut: OS X default value.
+@property (nonatomic) IBInspectable CGFloat trafficLightButtonsTopMargin;
+
 /// If set to YES, the title of the window will be hidden. Default: YES.
 @property (nonatomic) IBInspectable BOOL hidesTitle;
 

--- a/WAYWindow/WAYWindow.m
+++ b/WAYWindow/WAYWindow.m
@@ -256,6 +256,7 @@ static float kWAYWindowDefaultTrafficLightButtonsTopMargin = 0;
 	
 	self.styleMask |= NSFullSizeContentViewWindowMask;
 	_trafficLightButtonsLeftMargin = kWAYWindowDefaultTrafficLightButtonsLeftMargin;
+	_trafficLightButtonsTopMargin = kWAYWindowDefaultTrafficLightButtonsTopMargin;
 	
 	self.hidesTitle = YES;
 	
@@ -269,7 +270,7 @@ static float kWAYWindowDefaultTrafficLightButtonsTopMargin = 0;
 		if (_centerTrafficLightButtons)
 			frame.origin.y = NSHeight(standardButton.superview.frame)/2-NSHeight(standardButton.frame)/2;
 		else
-			frame.origin.y = NSHeight(standardButton.superview.frame)-NSHeight(standardButton.frame)-kWAYWindowDefaultTrafficLightButtonsTopMargin;
+			frame.origin.y = NSHeight(standardButton.superview.frame)-NSHeight(standardButton.frame)-_trafficLightButtonsTopMargin;
 		
 		frame.origin.x = _trafficLightButtonsLeftMargin +idx*(NSWidth(frame) + 6);
 		[standardButton setFrame:frame];


### PR DESCRIPTION
I have a case where I am creating a tall toolbar and placing a UI element that extends under the traffic light buttons, which causes the strict centered option to be a bit off for my usage.

This change allows you to specify a hard-coded top margin for the location of these buttons, similar to the left margin. It is only used if centering is turned off.