### PR TITLE
Fix Issues #5 & #22

### DIFF
--- a/WAYWindow/WAYWindow.m
+++ b/WAYWindow/WAYWindow.m
@@ -341,8 +341,14 @@ static float kWAYWindowDefaultTrafficLightButtonsTopMargin = 0;
 		else
 			frame.origin.y = NSHeight(standardButton.superview.frame)-NSHeight(standardButton.frame)-_trafficLightButtonsTopMargin;
 		
-		frame.origin.x = _trafficLightButtonsLeftMargin +idx*(NSWidth(frame) + 6);
-		[standardButton setFrame:frame];
+        CGFloat buttonMargin= 6;
+        if (NSApp.userInterfaceLayoutDirection == NSUserInterfaceLayoutDirectionLeftToRight) {
+            frame.origin.x = _trafficLightButtonsLeftMargin + idx*(NSWidth(frame) + buttonMargin);
+        } else {
+            frame.origin.x = NSMaxX(standardButton.superview.bounds) - _trafficLightButtonsLeftMargin - (idx+1)*NSWidth(frame) - idx*buttonMargin;
+        }
+        
+        [standardButton setFrame:frame];
 	}];
 }
 

--- a/WAYWindow/WAYWindow.m
+++ b/WAYWindow/WAYWindow.m
@@ -223,10 +223,15 @@ static float kWAYWindowDefaultTrafficLightButtonsTopMargin = 0;
 	_dummyTitlebarAccessoryViewController.fullScreenMinHeight = titleBarHeight;
 	[self addTitlebarAccessoryViewController:_dummyTitlebarAccessoryViewController];
 	
-	NSRect frame = self.frame;
-	frame.size.height += delta;
-	frame.origin.y -= delta;
-	
+    if (self.frameAutosaveName) {
+        [self setFrameUsingName:self.frameAutosaveName];
+    }
+    NSRect frame = self.frame;
+    frame.size.height += delta;
+    frame.size.height -= titleBarHeight; // prevent increasing the window height after every launch
+    frame.origin.y -= delta;
+    frame.origin.y += titleBarHeight; // prevent changing the window position after every launch
+    
 	[self _setNeedsLayout];
 	[self setFrame:frame display:NO]; // NO is important.
 }


### PR DESCRIPTION
- Fix window growing vertically at every launch when using frame autosaving.
- Position the traffic lights at either the left or right side of the window, depending on the user’s preference.